### PR TITLE
タスクを作成するAPI追加

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,9 @@ inputs:
   message:
     required: true
     description: 'Message to send'
-  taskUserId:
+  taskUserIds:
     required: false
-    description: 'User in charge of task. '
+    description: 'You can specify multiple users to be in charge of a task, separated by commas. example 1,3,5'
 runs:
   using: 'composite'
   steps:
@@ -34,4 +34,4 @@ runs:
         API_TOKEN: ${{ inputs.apiToken }}
         ROOM_ID: ${{ inputs.roomId }}
         MESSAGE: ${{ inputs.message }}
-        TASK_USER_ID: ${{ inputs.taskUserId }}
+        TASK_USER_IDS: ${{ inputs.taskUserIds }}

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   message:
     required: true
     description: 'Message to send'
+  taskUserId:
+    required: false
+    description: 'User in charge of task. '
 runs:
   using: 'composite'
   steps:
@@ -31,3 +34,4 @@ runs:
         API_TOKEN: ${{ inputs.apiToken }}
         ROOM_ID: ${{ inputs.roomId }}
         MESSAGE: ${{ inputs.message }}
+        TASK_USER_ID: ${{ inputs.taskUserId }}

--- a/main.rb
+++ b/main.rb
@@ -4,7 +4,7 @@ params = {
   token: ENV['API_TOKEN'],
   room_id: ENV['ROOM_ID'],
   message: ENV['MESSAGE'].delete_prefix('"').delete_suffix('"'),
-  task_user_id: ENV['TASK_USER_ID'],
+  task_user_ids: ENV['TASK_USER_IDS'],
 }
 
 if params[:message].empty?
@@ -13,9 +13,9 @@ end
 
 base_uri = URI.parse("https://api.chatwork.com/v2/rooms/#{params[:room_id]}/")
 body = "body=#{params[:message]}"
-if params[:task_user_id]
+if params[:task_user_ids]
   uri = base_uri + "tasks"
-  body += "&to_ids=#{params[:task_user_id]}"
+  body += "&to_ids=#{params[:task_user_ids]}"
 else
   uri = base_uri + "messages"
 end

--- a/main.rb
+++ b/main.rb
@@ -3,23 +3,31 @@ require 'net/http'
 params = { 
   token: ENV['API_TOKEN'],
   room_id: ENV['ROOM_ID'],
-  message: ENV['MESSAGE'].delete_prefix('"').delete_suffix('"')
+  message: ENV['MESSAGE'].delete_prefix('"').delete_suffix('"'),
+  task_user_id: ENV['TASK_USER_ID'],
 }
 
 if params[:message].empty?
   raise StandardError.new("empty message is not allowed.")
 end
 
-uri = URI.parse("https://api.chatwork.com/v2/rooms/#{params[:room_id]}/messages")
+base_uri = URI.parse("https://api.chatwork.com/v2/rooms/#{params[:room_id]}/")
+body = "body=#{params[:message]}"
+if params[:task_user_id]
+  uri = base_uri + "tasks"
+  body += "&to_ids=#{params[:task_user_id]}"
+else
+  uri = base_uri + "messages"
+end
+
 http = Net::HTTP.new(uri.host, uri.port)
 http.use_ssl = true
 
-body = "body=#{params[:message]}"
 headers = { "X-ChatWorkToken" => "#{params[:token]}" }
 
 response = http.post(uri.path, body, headers)
 
-if response.code == '200' && response.body.match(/^{"message_id":"[0-9]+"}/)
+if response.code == '200'
   puts response.body
 else
   raise StandardError.new("action failed! #{response.body}")


### PR DESCRIPTION
close #25 

タスクを追加できるようにしました。
taskUserIdに指定したユーザーに対するタスクを作成します
指定しない場合はメッセージを送信します。