### PR TITLE
fix: datetime become empty in example workflow

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -13,7 +13,7 @@ jobs:
       - name: "set current datetime"
         env:
           TZ: "Asia/Tokyo"
-        run: |
+        run: | # do not remove the space after `date +`. you need this.
           echo "CURRENT_DATETIME=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
       - name: "set arguments"
         id: "arguments"

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           TZ: "Asia/Tokyo"
         run: |
-          echo "CURRENT_DATETIME=$(date + "%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
+          echo "CURRENT_DATETIME=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
       - name: "set arguments"
         id: "arguments"
         run: |

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -13,7 +13,7 @@ jobs:
       - name: "set current datetime"
         env:
           TZ: "Asia/Tokyo"
-        run: |
+        run: | # do not remove the space after `date +`. you need this.
           echo "CURRENT_DATETIME=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
       - name: "set arguments"
         id: "arguments"

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           TZ: "Asia/Tokyo"
         run: |
-          echo "CURRENT_DATETIME=$(date + "%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
+          echo "CURRENT_DATETIME=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
       - name: "set arguments"
         id: "arguments"
         run: |


### PR DESCRIPTION
close #32 

dateの後に半角スペースが入っていると、正しく日時を出力することができない。